### PR TITLE
Migrate to ts-builds 3.0.1 and pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,0 @@
-# Hoist CLI tool binaries from peer dependencies
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-public-hoist-pattern[]=*vitest*
-public-hoist-pattern[]=typescript
-public-hoist-pattern[]=*rimraf*
-public-hoist-pattern[]=*cross-env*

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
   "devDependencies": {
     "@types/node": "^24.13.1",
     "@types/ssh2": "^1.15.5",
-    "ts-builds": "^2.8.2",
+    "ts-builds": "^3.0.1",
     "tsdown": "^0.22.2",
     "tsx": "^4.22.4"
   },
-  "packageManager": "pnpm@10.33.3+sha512.a19744364a7e248b92657a4ca5973f9354d21caf982579674b1c539f32c7420c47138ad8b1254df07aba9bc782d9b3029e3db34d5dbff974326eb74dac8ff489"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^1.15.5
         version: 1.15.5
       ts-builds:
-        specifier: ^2.8.2
-        version: 2.8.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.2(@types/node@24.13.1)(tsx@4.22.4))
+        specifier: ^3.0.1
+        version: 3.0.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.2(@types/node@24.13.1)(tsx@4.22.4))
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13))
@@ -2227,8 +2227,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-builds@2.8.2:
-    resolution: {integrity: sha512-gAnX6NN18S0zbd9a98oVN+7fOs0hwjVDy9QJokkWkwa30DJm7eovJF3gHABYyaOIIUa/34agMlHPgSm/D9/Dkg==}
+  ts-builds@3.0.1:
+    resolution: {integrity: sha512-dVPc85D+FaghDKYAJFDmM6fPabxhmLymoSBOG4cQvljEJSZM6z2lE1DaWFYSgXIQN1xSvkTDNzVfTFnWEuPClg==}
+    engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
       tsdown: ^0.x
@@ -4572,7 +4573,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-builds@2.8.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.2(@types/node@24.13.1)(tsx@4.22.4)):
+  ts-builds@3.0.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.2(@types/node@24.13.1)(tsx@4.22.4)):
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.4.1)
       '@types/node': 24.10.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,33 @@
+# Hoist CLI tool binaries from peer dependencies (migrated from .npmrc under pnpm 11)
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"
+  - "*vitest*"
+  - "typescript"
+  - "*rimraf*"
+  - "*cross-env*"
+
+# First-party packages we publish/control — trusted, so skip the 24h release-age
+# wait (pnpm 11 minimumReleaseAge default is 1440 minutes).
+minimumReleaseAgeExclude:
+  - ts-builds
+  - eslint-config-functype
+  - eslint-plugin-functype
+  - functype
+  - functype-log
+  - functype-os
+  - somamcp
+
+# pnpm 11 strictDepBuilds: approve/decline dependency build scripts explicitly.
+allowBuilds:
+  # esbuild's build script is not needed — its binary ships via @esbuild/<platform>
+  # optional dependencies.
+  esbuild: false
+  # cpu-features is an optional native addon ssh2 uses for crypto perf; ssh2 falls
+  # back to a pure-JS implementation when it's absent, so the build is not required.
+  cpu-features: false
+  # ssh2's install script only attempts to build the optional cpu-features addon.
+  ssh2: false
+  # tldjs's postinstall refreshes the public-suffix list; it ships with bundled data
+  # and works without running it.
+  tldjs: false


### PR DESCRIPTION
Migrates tooling to **ts-builds 3.0.1** and **pnpm 11.5.2**, following the documented ts-builds 2.x→3.0 / pnpm 10→11 runbook.

## Changes

| File | Change |
|------|--------|
| `package.json` | `ts-builds ^2.8.2 → ^3.0.1`; `packageManager` → `pnpm@11.5.2` (+ integrity hash) |
| `.npmrc` | **removed** — `public-hoist-pattern[]` lines are inert under pnpm 11 |
| `pnpm-workspace.yaml` | **new** — hoist patterns + supply-chain settings |
| `pnpm-lock.yaml` | re-resolved (stays `lockfileVersion: 9.0`) |

## `pnpm-workspace.yaml` decisions
- **`publicHoistPattern`** — migrated verbatim from `.npmrc`
- **`minimumReleaseAgeExclude`** — first-party packages (`functype`, `functype-os`, `functype-log`, `eslint-config-functype`, `eslint-plugin-functype`, `somamcp`, `ts-builds`). The functype family had been published <24h ago and tripped pnpm 11's release-age policy; trusted, so excluded rather than waiting.
- **`allowBuilds`** — `esbuild: false` (default; binary ships via `@esbuild/<platform>`), and `ssh2: false` / `cpu-features: false` / `tldjs: false`. ssh2's native `cpu-features` addon is an optional crypto-perf optimization — ssh2 runs pure-JS without it, and `tldjs` ships bundled public-suffix data. Declining avoids requiring a native build toolchain. Flip `ssh2`/`cpu-features` to `true` if the native perf bump is wanted later.

## Verification
- `pnpm validate` — format, lint, typecheck, **24 tests pass**, build ✅
- `ts-builds doctor` — **pnpm 11 ready, 0 errors**
- ssh2 confirmed working pure-JS (test suite passes with build scripts declined)

## CI
No workflow edits needed — `ci.yml` and `publish.yml` use `pnpm/action-setup@v4` with no pinned version, so they pick up pnpm 11 from the `packageManager` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)