### PR TITLE
Drop redundant npm install in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Validate
         run: pnpm validate
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Verify package contents
         run: |
           echo "Files to be published:"


### PR DESCRIPTION
Removes the `npm install -g npm@latest` step from `publish.yml`.

`.nvmrc` is pinned to **24**, which bundles **npm 11.5.1+**. The npm 10.x OIDC trusted-publishing bug ([npm/cli#8976](https://github.com/npm/cli/issues/8976)) that the step worked around is therefore already avoided by the Node version alone. The global upgrade step is redundant and is the flaky hosted-tool-cache pattern best avoided.

No other workflow changes; `npm publish --provenance` runs on the Node-24-bundled npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)